### PR TITLE
feat: allow omitting the stream argument when in --tail mode

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -141,7 +141,7 @@ async fn tail(
             .await?,
         aws_config.region().expect("region is provided").as_ref(),
         arn.trim_end_matches("*"),
-        &args.stream,
+        args.stream.as_deref(),
         args.filter.as_deref(),
         consumer,
     )
@@ -161,7 +161,8 @@ where
 {
     let template = GetLogEventsInputBuilder::default()
         .log_group_name(&args.group)
-        .log_stream_name(&args.stream)
+        // clap ensures that this option is present unless --tail is passed
+        .log_stream_name(args.stream.as_ref().unwrap())
         .limit(args.chunk_size as i32)
         .start_from_head(true)
         .start_time(start)
@@ -204,7 +205,8 @@ where
 {
     let template = FilterLogEventsInputBuilder::default()
         .log_group_name(&args.group)
-        .log_stream_names(&args.stream)
+        // clap ensures that this option is present unless --tail is passed
+        .log_stream_names(args.stream.as_deref().unwrap())
         .limit(args.chunk_size as i32)
         .start_time(start)
         .end_time(end)

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,8 +260,9 @@ enum Commands {
 struct LogArgs {
     /// group name
     group: String,
-    /// stream name
-    stream: String,
+    /// stream name. If not passed, will merge all streams in the Group.
+    #[arg(required_unless_present = "tail")]
+    stream: Option<String>,
     /// prints live log. Start, end, length and ui options are not supported.
     #[arg(short, long, default_value_t = false)]
     tail: bool,


### PR DESCRIPTION
The `StartLiveTail` API allows you to omit the stream name to tail all streams in a given group. This PR modifies this tool to allow you to omit the stream name (if and only if `--tail` is passed)

Related to #7 