### PR TITLE
feat: allow filtering streams by lastEventTimestamp

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use crate::time_arg::{parse_offset_or_duration, unix_now};
+use crate::time_arg::unix_now;
 #[cfg(feature = "ui")]
 use crate::ui;
 use crate::utils::{local_time, OptFuture};
@@ -75,18 +75,17 @@ pub async fn print(
         return tail(aws_config, client, args, &mut consumer).await;
     }
 
-    let now = unix_now()?;
-    let start = parse_offset_or_duration(&args.start, &now)?;
+    let start = args.start.timestamp_seconds();
     // TODO: add check for end and length at the same time
     let end = if let Some(end) = &args.end {
-        parse_offset_or_duration(end, &now)?
+        end.timestamp_seconds()
     } else if let Some(length) = &args.length {
         start
             + duration_str::parse(length)
                 .with_context(|| format!("cannot parse `{length}` as duration"))?
                 .as_millis() as i64
     } else {
-        now.as_millis() as i64
+        unix_now()?.as_millis() as i64
     };
 
     debug!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use anyhow::{Context, Result};
 use aws_sdk_cloudwatchlogs as cloudwatchlogs;
 use clap::{parser::ValueSource, Args, Parser, Subcommand};
 use itertools::Itertools;
+use time_arg::SimpleTime;
 
 mod groups;
 mod live_tail_client;
@@ -238,7 +239,7 @@ struct Cli {
 #[derive(Subcommand, Debug)]
 enum Commands {
     /// show logs
-    #[command(alias="logs")]
+    #[command(alias = "logs")]
     Log(LogArgs),
     /// show log groups
     Groups {
@@ -277,8 +278,8 @@ enum Commands {
         /// * Unix epoch time in seconds or milliseconds, ex:
         ///     * 1700000000
         ///     * 1700000000000
-        #[arg(short, long)]
-        start: Option<String>,
+        #[arg(short, long, verbatim_doc_comment)]
+        start: Option<SimpleTime>,
     },
     /// add or rewrite alias, use with with -- after alias to pass args
     Alias {
@@ -323,11 +324,11 @@ struct LogArgs {
     /// * Unix epoch time in seconds or milliseconds, ex:
     ///     * 1700000000
     ///     * 1700000000000
-    #[arg(short, long, verbatim_doc_comment, default_value_os_t = String::from("60m"))]
-    start: String,
+    #[arg(short, long, verbatim_doc_comment, default_value = "60m")]
+    start: SimpleTime,
     /// end time, format is the same as for start
     #[arg(short, long, default_value = None)]
-    end: Option<String>,
+    end: Option<SimpleTime>,
     /// either length or end is used, the format is same as offset for start
     #[arg(short, long, default_value = None)]
     length: Option<String>,

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -1,7 +1,4 @@
-use crate::{
-    time_arg::{parse_offset_or_duration, unix_now},
-    utils::format_opt_unix_ms,
-};
+use crate::{time_arg::SimpleTime, utils::format_opt_unix_ms};
 
 use super::utils::OptFuture;
 use anyhow::{Context, Result};
@@ -16,7 +13,7 @@ pub async fn print(
     prefix: Option<String>,
     verbose: bool,
     tab: bool,
-    start: Option<String>,
+    start: Option<SimpleTime>,
 ) -> Result<()> {
     let mut streams: Vec<LogStream> = vec![];
 
@@ -30,11 +27,7 @@ pub async fn print(
         template = template.order_by(OrderBy::LogStreamName).descending(false);
     }
 
-    let start_timestamp = if let Some(start) = &start {
-        parse_offset_or_duration(start, &unix_now()?)?
-    } else {
-        0
-    };
+    let start_timestamp = start.map(|s| s.timestamp_seconds()).unwrap_or(0);
 
     let mut opt_res = Some(template.clone().send_with(client).await);
     'outer: while let Some(res) = opt_res {


### PR DESCRIPTION
I have a bunch of groups with thousands of streams, of which I typically only care about the most recent few. This adds a new argument to the `streams` subcommand which will cause it to only show streams with an event after the given timestamp.

This also cleans up time parsing to be done inside `clap` instead of in the called functions, and just generally to be a bit tidier.