### PR TITLE
add subcommand alias for logs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -214,6 +214,7 @@ struct Cli {
 #[derive(Subcommand, Debug)]
 enum Commands {
     /// show logs
+    #[command(alias="logs")]
     Log(LogArgs),
     /// show log groups
     Groups {


### PR DESCRIPTION
continuing to experiment with this tool, I've found that I get mixed up about `log` vs `logs`, especially since all of the other methods are plural. What do you think about adding `logs` as a hidden alias?