### PR TITLE
chore: improve date logic to use chrono::DateTime throughout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ humansize = "2.1"
 anyhow = "1.0"
 toml_edit = "0.22"
 regex = "1.10"
-shellexpand = { version = "3.1", features = ["path"] } 
+shellexpand = { version = "3.1", features = ["path"] }
 itertools = "0.13"
 
 egui = { version = "0.27", optional = true }
@@ -49,3 +49,7 @@ sha2 = "0.10"
 base64 = "0.22"
 reqwest = { version = "0.12.10", features = ["stream"] }
 thiserror = "2.0"
+
+
+[dev-dependencies]
+chrono-tz = "0.10"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use std::{
 use ::log::debug;
 use anyhow::{Context, Result};
 use aws_sdk_cloudwatchlogs as cloudwatchlogs;
+use chrono::{DateTime, Utc};
 use clap::{parser::ValueSource, Args, Parser, Subcommand};
 use itertools::Itertools;
 
@@ -238,7 +239,7 @@ struct Cli {
 #[derive(Subcommand, Debug)]
 enum Commands {
     /// show logs
-    #[command(alias="logs")]
+    #[command(alias = "logs")]
     Log(LogArgs),
     /// show log groups
     Groups {
@@ -277,8 +278,8 @@ enum Commands {
         /// * Unix epoch time in seconds or milliseconds, ex:
         ///     * 1700000000
         ///     * 1700000000000
-        #[arg(short, long)]
-        start: Option<String>,
+        #[arg(short, long, verbatim_doc_comment, value_parser = time_arg::parse)]
+        start: Option<DateTime<Utc>>,
     },
     /// add or rewrite alias, use with with -- after alias to pass args
     Alias {
@@ -323,11 +324,11 @@ struct LogArgs {
     /// * Unix epoch time in seconds or milliseconds, ex:
     ///     * 1700000000
     ///     * 1700000000000
-    #[arg(short, long, verbatim_doc_comment, default_value_os_t = String::from("60m"))]
-    start: String,
+    #[arg(short, long, verbatim_doc_comment, default_value = "60m", value_parser = time_arg::parse)]
+    start: DateTime<Utc>,
     /// end time, format is the same as for start
-    #[arg(short, long, default_value = None)]
-    end: Option<String>,
+    #[arg(short, long, default_value = None, value_parser = time_arg::parse)]
+    end: Option<DateTime<Utc>>,
     /// either length or end is used, the format is same as offset for start
     #[arg(short, long, default_value = None)]
     length: Option<String>,

--- a/src/time_arg.rs
+++ b/src/time_arg.rs
@@ -1,100 +1,161 @@
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
-use chrono::{DateTime, Days, Local, NaiveTime};
+use chrono::{DateTime, Days, Local, NaiveDate, NaiveTime, TimeDelta, TimeZone, Utc};
 
-pub fn unix_now() -> Result<Duration> {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .context("cannot get unix time as duration")
+pub fn parse(value: &str) -> Result<DateTime<Utc>> {
+    parse_relative_to(value, Utc::now(), Local)
 }
 
-pub fn parse_offset_or_duration(value: &str, unix_now: &Duration) -> Result<i64> {
-    parse_as_epoch_ms(value)
-        .or_else(|_| {
-            duration_str::parse(value).map(|o| unix_now.saturating_sub(o).as_millis() as i64)
-        })
-        .or_else(|_| {
-            NaiveTime::parse_from_str(value, "%H:%M")
-                .or_else(|_| NaiveTime::parse_from_str(value, "%H:%M:%S"))
-                .or_else(|_| NaiveTime::parse_from_str(value, "%H:%M:%S.%3f"))
-                .map_err(|_| 0)
-                .and_then(|n| {
-                    DateTime::from_timestamp_millis(unix_now.as_millis() as i64)
-                        .unwrap()
-                        .with_timezone(&Local)
-                        .with_time(n)
-                        .single()
-                        .map(|v| {
-                            if v.timestamp_millis() > (unix_now.as_millis() as i64) {
-                                v.checked_sub_days(Days::new(1)).unwrap().timestamp_millis()
-                            } else {
-                                v.timestamp_millis()
-                            }
-                        })
-                        .ok_or(0)
-                })
-        })
-        .or_else(|_| {
-            NaiveTime::parse_from_str(value, "%H:%MZ")
-                .or_else(|_| NaiveTime::parse_from_str(value, "%H:%M:%SZ"))
-                .or_else(|_| NaiveTime::parse_from_str(value, "%H:%M:%S.%3fZ"))
-                .map_err(|_| 0)
-                .and_then(|n| {
-                    DateTime::from_timestamp_millis(unix_now.as_millis() as i64)
-                        .unwrap()
-                        .with_time(n)
-                        .single()
-                        .map(|v| {
-                            if v.timestamp_millis() > (unix_now.as_millis() as i64) {
-                                v.checked_sub_days(Days::new(1)).unwrap().timestamp_millis()
-                            } else {
-                                v.timestamp_millis()
-                            }
-                        })
-                        .ok_or(0)
-                })
-        })
-        .or_else(|_| DateTime::parse_from_rfc3339(value).map(|d| d.timestamp_millis()))
-        .with_context(|| {
-            format!("failed to parse `{value}` as duration, time, UTC time or RFC3339")
-        })
-}
-
-fn parse_as_epoch_ms(candidate: &str) -> anyhow::Result<i64> {
+fn parse_as_epoch_ms(candidate: &str) -> anyhow::Result<chrono::DateTime<Utc>> {
     let ms = candidate.parse::<i64>()?;
     if ms > 946684800000 {
         // 2000-01-01 in ms
-        Ok(ms)
+        DateTime::<Utc>::from_timestamp_millis(ms).ok_or_else(|| anyhow::anyhow!("invalid time"))
     } else {
-        Ok(ms * 1000)
+        DateTime::<Utc>::from_timestamp(ms, 0).ok_or_else(|| anyhow::anyhow!("invalid time"))
     }
+}
+
+fn parse_as_duration_offset(value: &str, now: DateTime<Utc>) -> Result<DateTime<Utc>> {
+    let duration: Duration = duration_str::parse(value).context("unable to parse duration")?;
+    let time_delta =
+        TimeDelta::from_std(duration).context("unable to convert duration to TimeDelta")?;
+    let then = now
+        .checked_sub_signed(time_delta)
+        .ok_or_else(|| anyhow::anyhow!("invalid duration {}", value))?;
+    Ok(then)
+}
+
+fn parse_as_bare_time<Tz>(value: &str, now: DateTime<Utc>, local_zone: Tz) -> Result<DateTime<Utc>>
+where
+    Tz: TimeZone,
+{
+    let time = NaiveTime::parse_from_str(value, "%H:%M")
+        .or_else(|_| NaiveTime::parse_from_str(value, "%H:%M:%S"))
+        .or_else(|_| NaiveTime::parse_from_str(value, "%H:%M:%S.%3f"))?;
+
+    let then = now
+        .with_timezone(&local_zone)
+        .with_time(time)
+        .single()
+        .ok_or_else(|| anyhow::anyhow!("ambiguous time {}", value))?;
+    let adjusted = if then > now {
+        then.checked_sub_days(Days::new(1))
+            .context("unable to subtract days")?
+    } else {
+        then
+    };
+    Ok(adjusted.with_timezone(&Utc))
+}
+
+fn parse_as_zoned_time(value: &str, now: DateTime<Utc>) -> Result<DateTime<Utc>> {
+    let time = NaiveTime::parse_from_str(value, "%H:%MZ")
+        .or_else(|_| NaiveTime::parse_from_str(value, "%H:%M:%SZ"))
+        .or_else(|_| NaiveTime::parse_from_str(value, "%H:%M:%S.%3fZ"))?;
+
+    let then = now
+        .with_time(time)
+        .single()
+        .ok_or_else(|| anyhow::anyhow!("ambigious time"))?;
+    let adjusted = if then > now {
+        then.checked_sub_days(Days::new(1))
+            .context("unable to subtract days")?
+    } else {
+        then
+    };
+    Ok(adjusted.with_timezone(&Utc))
+}
+
+fn parse_as_bare_date<Tz>(value: &str, local_zone: Tz) -> Result<DateTime<Utc>>
+where
+    Tz: TimeZone,
+{
+    let date = NaiveDate::parse_from_str(value, "%Y-%m-%d").context("Error parsing bare date")?;
+    let midnight = NaiveTime::MIN;
+    date.and_time(midnight)
+        .and_local_timezone(local_zone)
+        .earliest()
+        .ok_or(anyhow::anyhow!("ambiguous time"))
+        .map(|d| d.with_timezone(&Utc))
+}
+
+fn parse_relative_to<Tz>(value: &str, now: DateTime<Utc>, local_zone: Tz) -> Result<DateTime<Utc>>
+where
+    Tz: TimeZone,
+{
+    parse_as_epoch_ms(value)
+        .or_else(|_| parse_as_duration_offset(value, now))
+        .or_else(|_| parse_as_bare_time(value, now, local_zone.clone()))
+        .or_else(|_| parse_as_zoned_time(value, now))
+        .or_else(|_| {
+            DateTime::parse_from_rfc3339(value)
+                .context("error parsing RFC 3339 DateTime")
+                .map(|d| d.with_timezone(&Utc))
+        })
+        .or_else(|_| parse_as_bare_date(value, local_zone.clone()))
+        .with_context(|| {
+            format!("failed to parse `{value}` as duration, time, UTC time, date or RFC3339")
+        })
 }
 
 #[cfg(test)]
 mod test {
+    use chrono::SecondsFormat;
+
     use super::*;
 
     #[test]
     fn offset_or_duration() {
-        let ts = Duration::from_secs(
-            DateTime::parse_from_rfc3339("2024-01-02T03:04:05.678Z")
-                .unwrap()
-                .timestamp() as u64,
-        );
-        // TODO: write proper test, maybe change local time zone or just copy implementation logic
-        // TODO: cover other cases
-        assert!(parse_offset_or_duration("10:23", &ts).is_ok());
-        assert!(parse_offset_or_duration("10:23:45", &ts).is_ok());
-        assert!(parse_offset_or_duration("10:23:45.678", &ts).is_ok());
+        let ts = DateTime::parse_from_rfc3339("2024-01-02T03:04:05.678Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let local_zone = chrono_tz::US::Pacific;
 
         assert_eq!(
-            parse_offset_or_duration("1700000000", &ts).unwrap(),
+            parse_relative_to("10:23", ts, local_zone)
+                .expect("should parse")
+                .to_rfc3339(),
+            "2024-01-01T18:23:00+00:00"
+        );
+        assert_eq!(
+            parse_relative_to("10:23:45", ts, local_zone)
+                .expect("should parse")
+                .to_rfc3339(),
+            "2024-01-01T18:23:45+00:00"
+        );
+        assert_eq!(
+            parse_relative_to("10:23:45.678", ts, local_zone)
+                .expect("should parse")
+                .to_rfc3339_opts(SecondsFormat::Millis, true),
+            "2024-01-01T18:23:45.678Z"
+        );
+
+        assert_eq!(
+            parse_relative_to("1700000000", ts, local_zone)
+                .unwrap()
+                .timestamp_millis(),
             1700000000000
         );
         assert_eq!(
-            parse_offset_or_duration("1700000000000", &ts).unwrap(),
+            parse_relative_to("1700000000000", ts, local_zone)
+                .unwrap()
+                .timestamp_millis(),
             1700000000000
+        );
+
+        assert_eq!(
+            parse_relative_to("10m", ts, local_zone)
+                .expect("should parse")
+                .to_rfc3339(),
+            "2024-01-02T02:54:05.678+00:00"
+        );
+
+        assert_eq!(
+            parse_relative_to("1m30s", ts, local_zone)
+                .expect("should parse")
+                .to_rfc3339(),
+            "2024-01-02T03:02:35.678+00:00"
         );
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,6 @@
-use std::{
-    future::Future,
-    time::{Duration, SystemTime},
-};
+use std::future::Future;
 
-use chrono::{DateTime, Local};
+use chrono::{DateTime, Local, Utc};
 
 pub trait OptFuture<T, F: Future<Output = T>> {
     async fn resolve(self) -> Option<T>;
@@ -19,17 +16,15 @@ impl<T, F: Future<Output = T>> OptFuture<T, F> for Option<F> {
     }
 }
 
-pub fn local_time(unix_time_ms: i64) -> DateTime<Local> {
-    DateTime::<Local>::from(
-        SystemTime::UNIX_EPOCH
-            .checked_add(Duration::from_millis(unix_time_ms as u64))
-            .unwrap(),
-    )
+pub fn local_time(timestamp: DateTime<Utc>) -> DateTime<Local> {
+    timestamp.with_timezone(&Local)
 }
 
 pub fn format_opt_unix_ms(opt_unix_time_ms: Option<i64>) -> String {
+    let local = Local;
     opt_unix_time_ms
-        .map(local_time)
+        .and_then(DateTime::<Utc>::from_timestamp_millis)
+        .map(|u| u.with_timezone(&local))
         .map(|d| d.to_rfc3339())
         .unwrap_or_default()
 }


### PR DESCRIPTION
This code was pretty, but I think it was confusing to have `i64` representing time throughout the codebase, and to never entirely be clear on what's in what time zone.

This migrates all code to use `DateTime<Utc>` to represent timestamps, and to convert to/from `i64` only at the service boundaries. It also centralizes the argument parsing to be done in `clap` instead of in the actual code.